### PR TITLE
chore: add tech writers as codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -37,4 +37,11 @@
 # https://help.github.com/articles/about-codeowners/
 # https://github.com/blog/2392-introducing-code-owners/
 
+# Default owners of the "kyma-companion" repository
 * @kyma-project/ai-force
+
+# Owners of documentation files in the "kyma-companion" repository
+*.md @kyma-project/technical-writers
+
+# All files and subdirectories in /docs
+/docs/ @kyma-project/technical-writers


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

## Description

Changes proposed in this pull request:

- Add technical writers as codeowners

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
